### PR TITLE
Implement dap debugging for rust

### DIFF
--- a/CARGO_PLAN.md
+++ b/CARGO_PLAN.md
@@ -6,21 +6,24 @@
 - `detect(root)` checks for `Cargo.toml`
 - Register module in `discover.lua`
 
-## Step 2: Core Actions (No Debug) - IN PROGRESS
+## Step 2: Core Actions ✅ DONE
 
 ### Options ✅ DONE
 - `PROFILE` ✅ - Built-in profiles (dev/release/test/bench) + user-defined input via picker composition
 - `TARGET` ✅ - Binary picker via `cargo metadata --format-version=1 --no-deps`, filters for `kind: ["bin"]`
-- `EXECUTABLE_ARGUMENTS` - Not needed for MVP
-- `BUILD_BEFORE_RUN` - Not needed (cargo handles automatically)
+- `EXECUTABLE_PATH` ✅ - File picker for manual override, default computed from profile + target
+- `EXECUTABLE_ARGUMENTS` ✅ - String input for CLI args
+- `BUILD_BEFORE_RUN` ✅ - Boolean picker, default `true`
 
-### Actions
+### Actions ✅ DONE
 - `options()` ✅ - Configure settings
 - `build()` ✅ - `cargo build --profile <profile> --bin <target>` with spinner notification
 - `build_all()` ✅ - `cargo build --profile <profile> --all-targets` with spinner notification
 - `check()` ✅ - `cargo check --profile <profile>` with spinner notification
-- `run()` ❌ - Not implemented
-- `test()` ❌ - Not implemented
+- `clean()` ✅ - `cargo clean` with spinner notification
+- `run()` ✅ - `cargo run --profile <profile> --bin <target>` (fire-and-forget)
+- `test()` ✅ - `cargo test --profile <profile>` with spinner notification
+- `debug()` ✅ - Build + DAP launch
 
 ### Implementation Notes
 
@@ -34,22 +37,24 @@
 - Parses `packages[].targets[]` and filters for `kind: ["bin"]`
 - Returns sorted list of binary target names
 
+**Executable Path Computation:**
+- `get_default_executable_path(profile, target)` computes path
+- Queries cargo metadata for `target_directory`
+- Maps profile to directory: dev/test → debug, release/bench → release, custom → custom
+- Appends `.exe` on Windows
+- User can override via `EXECUTABLE_PATH` option
+
 **Build Flow:**
 - `get_build_context()` - Gets required PROFILE and TARGET options (prompts user if not set)
 - `setup_opts.task()` - Runs cargo command via configured task runner
 - Spinner notification during build, success/failure on completion
 
-## Step 3: Remaining Actions
-
-### run()
-- `cargo run --bin <target> --profile <profile> [-- args]`
-- Reuse build context? Add EXECUTABLE_ARGUMENTS option?
-
-### test()
-- `cargo test [<testname>]`
-- Test picker: `cargo test -- --list` to discover tests? Or input picker?
+**Debug Flow:**
+- Gets profile/target via `get_build_context()`
+- Computes executable path (default from metadata, or override from options)
+- Optionally builds first (BUILD_BEFORE_RUN, default: true)
+- Launches via `foundry.debug` module with `'rust'` filetype
 
 ## Future
 
-- `debug()` - Build + DAP launch
 - `debug_test()` - Debug specific test

--- a/lua/foundry/cargo.lua
+++ b/lua/foundry/cargo.lua
@@ -25,17 +25,20 @@ local function profile_picker(prompt, default)
 	return result
 end
 
-local function get_target_options()
+local function get_metadata()
 	local result = vim.system({ 'cargo', 'metadata', '--format-version=1', '--no-deps' }, { cwd = vim.fn.getcwd() }):wait()
 
 	if result.code ~= 0 then
-		foundry_notify.notify('cargo metadata failed: ' .. (result.stderr or 'unknown error'), { level = vim.log.levels.ERROR })
-		return {}
+		return nil
 	end
 
-	local metadata = vim.json.decode(result.stdout)
+	return vim.json.decode(result.stdout)
+end
+
+local function get_target_options()
+	local metadata = get_metadata()
 	if not metadata then
-		foundry_notify.notify('cargo metadata returned invalid JSON', { level = vim.log.levels.ERROR })
+		foundry_notify.notify('cargo metadata failed', { level = vim.log.levels.ERROR })
 		return {}
 	end
 
@@ -104,15 +107,13 @@ local function get_default_executable_path(profile, target)
 		bench = 'release',
 	}
 
-	local result = vim.system({ 'cargo', 'metadata', '--format-version=1', '--no-deps' }, { cwd = vim.fn.getcwd() }):wait()
-
-	if result.code ~= 0 then
-		foundry_notify.notify('cargo metadata failed: ' .. (result.stderr or 'unknown error'), { level = vim.log.levels.ERROR })
+	local metadata = get_metadata()
+	if not metadata then
+		foundry_notify.notify('cargo metadata failed', { level = vim.log.levels.ERROR })
 		return nil
 	end
 
-	local metadata = vim.json.decode(result.stdout)
-	if not metadata or not metadata.target_directory then
+	if not metadata.target_directory then
 		foundry_notify.notify('cargo metadata missing target_directory', { level = vim.log.levels.ERROR })
 		return nil
 	end

--- a/lua/foundry/cargo.lua
+++ b/lua/foundry/cargo.lua
@@ -1,6 +1,7 @@
 local M = {}
 local foundry_notify = require('foundry.notify')
 local foundry_options = require('foundry.options')
+local foundry_debug = require('foundry.debug')
 local setup_opts = require('foundry').opts
 
 function M.detect(root)
@@ -58,7 +59,11 @@ end
 local options = {
 	PROFILE = { 'profile', 'Profile', profile_picker },
 	TARGET = { 'target', 'Target', foundry_options.select_picker(get_target_options) },
+	EXECUTABLE_PATH = { 'exe_path', 'Executable Path', foundry_options.file_picker() },
+	EXECUTABLE_ARGUMENTS = { 'exe_args', 'Executable Arguments', foundry_options.input_picker() },
+	BUILD_BEFORE_RUN = { 'build_before_run', 'Build before run', foundry_options.boolean_picker() },
 }
+options = vim.tbl_deep_extend('force', options, foundry_debug.options)
 
 local function get_option(option, default, show_ui)
 	show_ui = show_ui or false
@@ -89,6 +94,36 @@ local function get_build_context()
 	end
 
 	return profile, target
+end
+
+local function get_default_executable_path(profile, target)
+	local PROFILE_TO_DIR = {
+		dev = 'debug',
+		test = 'debug',
+		release = 'release',
+		bench = 'release',
+	}
+
+	local result = vim.system({ 'cargo', 'metadata', '--format-version=1', '--no-deps' }, { cwd = vim.fn.getcwd() }):wait()
+
+	if result.code ~= 0 then
+		foundry_notify.notify('cargo metadata failed: ' .. (result.stderr or 'unknown error'), { level = vim.log.levels.ERROR })
+		return nil
+	end
+
+	local metadata = vim.json.decode(result.stdout)
+	if not metadata or not metadata.target_directory then
+		foundry_notify.notify('cargo metadata missing target_directory', { level = vim.log.levels.ERROR })
+		return nil
+	end
+
+	local exe_name = target
+	if vim.fn.has('win32') == 1 then
+		exe_name = exe_name .. '.exe'
+	end
+
+	local profile_dir = PROFILE_TO_DIR[profile] or profile
+	return vim.fs.joinpath(metadata.target_directory, profile_dir, exe_name)
 end
 
 function M.build()
@@ -189,6 +224,39 @@ function M.test()
 	end
 end
 
+function M.debug()
+	local profile, target = get_build_context()
+	if not profile or not target then
+		return
+	end
+
+	local executable_path = get_option(options.EXECUTABLE_PATH, get_default_executable_path(profile, target))
+	if not executable_path then
+		foundry_notify.notify('No executable path available', { level = vim.log.levels.ERROR })
+		return
+	end
+
+	if not vim.fn.filereadable(executable_path) then
+		foundry_notify.notify('Executable does not exist: ' .. executable_path, { level = vim.log.levels.ERROR })
+		return
+	end
+
+	local build_before_run = get_option(options.BUILD_BEFORE_RUN, 'true') == 'true'
+	if build_before_run then
+		M.build()
+	end
+
+	local arguments = get_option(options.EXECUTABLE_ARGUMENTS, '') or ''
+	local args = vim.fn.split(arguments, ' ')
+
+	local debug = require('foundry.debug')
+	local result, reason = debug.debug('rust', executable_path, args)
+
+	if not result then
+		foundry_notify.notify(reason, { level = vim.log.levels.ERROR })
+	end
+end
+
 function M.options()
 	local menu_options = {}
 	for _, item in pairs(options) do
@@ -224,6 +292,7 @@ function M.actions()
 		{ name = 'Build All', action = M.build_all },
 		{ name = 'Check', action = M.check },
 		{ name = 'Clean', action = M.clean },
+		{ name = 'Debug', action = M.debug },
 		{ name = 'Run', action = M.run },
 		{ name = 'Test', action = M.test },
 		{ name = 'Options', action = M.options },


### PR DESCRIPTION
Allows debugger adapter specification and whether to use an existing launch profile.

Closes #13 